### PR TITLE
Add libnvidia-gpucomp to the list of NVIDIA driver libraries

### DIFF
--- a/pressure-vessel/runtime.c
+++ b/pressure-vessel/runtime.c
@@ -4053,6 +4053,7 @@ collect_graphics_libraries_patterns (GPtrArray *patterns)
     "libnvidia-glcore.so.*",
     "libnvidia-glsi.so.*",
     "libnvidia-glvkspirv.so.*",
+    "libnvidia-gpucomp.so.*",
     "libnvidia-ifr.so.*",
     "libnvidia-ml.so.*",
     "libnvidia-opencl.so.*",


### PR DESCRIPTION
Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.